### PR TITLE
Fix saved-state barcode bitset sizing on Windows

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: magenta
 Type: Package
 Title: Individual-Based Simulation Model of Malaria Epidemiology and Genomics
-Version: 1.3.6
+Version: 1.3.7
 Authors@R: 
     c(person(given = "OJ",
              family = "Watson",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 ## magenta 1.3.6
 
+* Fix to saved state initialisation of barcode bitset sizing on Windows
+
+## magenta 1.3.6
+
 * Reloading models saved to file working again
 * New function `update_saved_state_barcode_plaf` to update plaf in saved simulation
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-## magenta 1.3.6
+## magenta 1.3.7
 
 * Fix to saved state initialisation of barcode bitset sizing on Windows
 

--- a/src/main_saved_init.cpp
+++ b/src/main_saved_init.cpp
@@ -304,6 +304,19 @@ Rcpp::List Simulation_Saved_Init_cpp(Rcpp::List param_list)
   if (parameters_List.containsElementNamed("g_barcode_length")) {
     Parameters::g_barcode_length = Rcpp::as<unsigned int>(parameters_List["g_barcode_length"]);
   }
+
+  // Ensure the static temporary barcodes used across the simulation are resized
+  // to match the (potentially) updated barcode configuration contained in the
+  // saved state.  Without this step different static initialisation orders on
+  // some platforms (e.g. Windows) leave these bitsets with zero length, which
+  // then leads to out-of-bounds writes when the saved infection and mosquito
+  // barcodes are unpacked.
+  Strain::temp_barcode = boost::dynamic_bitset<>(Parameters::g_barcode_length);
+  Strain::temp_identity_barcode = boost::dynamic_bitset<>(Parameters::g_ibd_length);
+  Strain::temp_crossovers = boost::dynamic_bitset<>(Parameters::g_num_loci);
+  Strain::temp_barcode_pair = std::vector<boost::dynamic_bitset<> >(
+    2, boost::dynamic_bitset<>(Parameters::g_barcode_length)
+  );
   if (parameters_List.containsElementNamed("g_plaf")) {
     Parameters::g_plaf = Rcpp::as<std::vector<double> >(parameters_List["g_plaf"]);
   }


### PR DESCRIPTION
## Summary
- resize the shared Strain temporary bitsets after loading barcode parameters from a saved state
- prevent out-of-bounds writes when unpacking saved human and mosquito barcodes on platforms where static initialization order differs

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e6bf80da2c8329961063888468503e